### PR TITLE
Fixed 0.11.1 release issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ mkmf.log
 worker.yml
 worker2.yml
 /vendor/bundle
+/Gemfile.lock
+/.ruby-version

--- a/reference/en/cloudsql_instance.md
+++ b/reference/en/cloudsql_instance.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: cloudsql_instance | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / cloudsql_instance en <a href="/reference/ja/cloudsql_instance.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / cloudsql_instance <a href="/reference/ja/cloudsql_instance.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/index.md
+++ b/reference/en/index.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> /  en <a href="/reference/ja/index.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> /  <a href="/reference/ja/index.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/messaging/http.md
+++ b/reference/en/messaging/http.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: http | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / http en <a href="/reference/ja/messaging/http.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / http <a href="/reference/ja/messaging/http.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/messaging/mqtt.md
+++ b/reference/en/messaging/mqtt.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: mqtt | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / mqtt en <a href="/reference/ja/messaging/mqtt.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / mqtt <a href="/reference/ja/messaging/mqtt.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/authority.md
+++ b/reference/en/resources/authority.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: authority | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / authority en <a href="/reference/ja/resources/authority.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / authority <a href="/reference/ja/resources/authority.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/client_version.md
+++ b/reference/en/resources/client_version.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: client_version | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / client_version en <a href="/reference/ja/resources/client_version.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / client_version <a href="/reference/ja/resources/client_version.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/cloudsql.md
+++ b/reference/en/resources/cloudsql.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: cloudsql | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / cloudsql en <a href="/reference/ja/resources/cloudsql.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / cloudsql <a href="/reference/ja/resources/cloudsql.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/container.md
+++ b/reference/en/resources/container.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: container | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / container en <a href="/reference/ja/resources/container.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / container <a href="/reference/ja/resources/container.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/image.md
+++ b/reference/en/resources/image.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: image | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / image en <a href="/reference/ja/resources/image.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / image <a href="/reference/ja/resources/image.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/organization.md
+++ b/reference/en/resources/organization.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: organization | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / organization en <a href="/reference/ja/resources/organization.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / organization <a href="/reference/ja/resources/organization.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/project.md
+++ b/reference/en/resources/project.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: project | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / project en <a href="/reference/ja/resources/project.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / project <a href="/reference/ja/resources/project.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/stage.md
+++ b/reference/en/resources/stage.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: stage | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / stage en <a href="/reference/ja/resources/stage.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / stage <a href="/reference/ja/resources/stage.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/team.md
+++ b/reference/en/resources/team.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: team | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / team en <a href="/reference/ja/resources/team.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / team <a href="/reference/ja/resources/team.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/en/resources/worker.md
+++ b/reference/en/resources/worker.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: worker | magellan-cli-0.11 (en) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / worker en <a href="/reference/ja/resources/worker.html">ja</a>
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/en">magellan-cli-0.11</a> / worker <a href="/reference/ja/resources/worker.html">ja</a> en
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-en
 ---
 

--- a/reference/ja/cloudsql_instance.md
+++ b/reference/ja/cloudsql_instance.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: cloudsql_instance | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / cloudsql_instance <a href="/reference/en/cloudsql_instance.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / cloudsql_instance ja <a href="/reference/en/cloudsql_instance.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/index.md
+++ b/reference/ja/index.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> /  <a href="/reference/en/index.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> /  ja <a href="/reference/en/index.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/messaging/http.md
+++ b/reference/ja/messaging/http.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: http | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / http <a href="/reference/en/messaging/http.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / http ja <a href="/reference/en/messaging/http.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/messaging/mqtt.md
+++ b/reference/ja/messaging/mqtt.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: mqtt | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / mqtt <a href="/reference/en/messaging/mqtt.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / mqtt ja <a href="/reference/en/messaging/mqtt.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/authority.md
+++ b/reference/ja/resources/authority.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: authority | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / authority <a href="/reference/en/resources/authority.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / authority ja <a href="/reference/en/resources/authority.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/client_version.md
+++ b/reference/ja/resources/client_version.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: client_version | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / client_version <a href="/reference/en/resources/client_version.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / client_version ja <a href="/reference/en/resources/client_version.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/cloudsql.md
+++ b/reference/ja/resources/cloudsql.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: cloudsql | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / cloudsql <a href="/reference/en/resources/cloudsql.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / cloudsql ja <a href="/reference/en/resources/cloudsql.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/container.md
+++ b/reference/ja/resources/container.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: container | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / container <a href="/reference/en/resources/container.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / container ja <a href="/reference/en/resources/container.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/image.md
+++ b/reference/ja/resources/image.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: image | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / image <a href="/reference/en/resources/image.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / image ja <a href="/reference/en/resources/image.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/organization.md
+++ b/reference/ja/resources/organization.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: organization | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / organization <a href="/reference/en/resources/organization.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / organization ja <a href="/reference/en/resources/organization.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/project.md
+++ b/reference/ja/resources/project.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: project | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / project <a href="/reference/en/resources/project.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / project ja <a href="/reference/en/resources/project.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/stage.md
+++ b/reference/ja/resources/stage.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: stage | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / stage <a href="/reference/en/resources/stage.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / stage ja <a href="/reference/en/resources/stage.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/team.md
+++ b/reference/ja/resources/team.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: team | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / team <a href="/reference/en/resources/team.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / team ja <a href="/reference/en/resources/team.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 

--- a/reference/ja/resources/worker.md
+++ b/reference/ja/resources/worker.md
@@ -1,7 +1,7 @@
 ---
 layout: index
 title: worker | magellan-cli-0.11 (ja) | Reference
-breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / worker <a href="/reference/en/resources/worker.html">en</a> ja
+breadcrumb: <a href="/">Top</a> / <a href="/reference">Reference</a> / <a href="/reference/magellan-cli/ja">magellan-cli-0.11</a> / worker ja <a href="/reference/en/resources/worker.html">en</a>
 sidemenu: sidemenu/reference/magellan-cli/sidemenu-ja
 ---
 


### PR DESCRIPTION
I tried to release 0.11.1 but failed.

```console
yamada@WEZEN% bundle exec rake release
magellan-cli 0.11.1 built to pkg/magellan-cli-0.11.1.gem.
rake aborted!
There are files that need to be committed first.
/opt/rbenv/versions/2.6/bin/bundle:23:in `load'
/opt/rbenv/versions/2.6/bin/bundle:23:in `<main>'
Tasks: TOP => release => release:guard_clean
(See full trace by running task with --trace)
yamada@WEZEN% git status
On branch master
Your branch is up to date with 'origin/master'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   reference/en/cloudsql_instance.md
	modified:   reference/en/index.md
	modified:   reference/en/messaging/http.md
	modified:   reference/en/messaging/mqtt.md
	modified:   reference/en/resources/authority.md
	modified:   reference/en/resources/client_version.md
	modified:   reference/en/resources/cloudsql.md
	modified:   reference/en/resources/container.md
	modified:   reference/en/resources/image.md
	modified:   reference/en/resources/organization.md
	modified:   reference/en/resources/project.md
	modified:   reference/en/resources/stage.md
	modified:   reference/en/resources/team.md
	modified:   reference/en/resources/worker.md
	modified:   reference/ja/cloudsql_instance.md
	modified:   reference/ja/index.md
	modified:   reference/ja/messaging/http.md
	modified:   reference/ja/messaging/mqtt.md
	modified:   reference/ja/resources/authority.md
	modified:   reference/ja/resources/client_version.md
	modified:   reference/ja/resources/cloudsql.md
	modified:   reference/ja/resources/container.md
	modified:   reference/ja/resources/image.md
	modified:   reference/ja/resources/organization.md
	modified:   reference/ja/resources/project.md
	modified:   reference/ja/resources/stage.md
	modified:   reference/ja/resources/team.md
	modified:   reference/ja/resources/worker.md

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	.ruby-version
	Gemfile.lock

no changes added to commit (use "git add" and/or "git commit -a")
```

So I updated references by `bundle exec rake reference`,
and updated .gitignore file.
